### PR TITLE
feat/pro-vrf: support enum lookup and refactor OauthProvider

### DIFF
--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/Enums.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/Enums.kt
@@ -1,6 +1,6 @@
 package io.github.wliamp.pro.vrf
 
-internal enum class Oauth {
+enum class Oauth {
     GOOGLE,
     FACEBOOK,
     ZALO

--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IFacebook.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IFacebook.kt
@@ -5,7 +5,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
 internal class IFacebook internal constructor(
-    private val props: Properties.FacebookProps,
+    private val props: OauthProps.FacebookProps,
     private val webClient: WebClient
 ) : IOauth {
     private val oauth = Oauth.FACEBOOK

--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IGoogle.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IGoogle.kt
@@ -1,6 +1,6 @@
 package io.github.wliamp.pro.vrf
 
-import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpMethod
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
@@ -10,54 +10,30 @@ internal class IGoogle internal constructor(
 ) : IOauth {
     private val oauth = Oauth.GOOGLE
 
-    private val url = "${props.baseUrl}${props.uri}"
-
     override fun verify(token: String): Mono<Boolean> =
         props.takeIf { it.clientId.isNotBlank() }
             ?.let { p ->
-                fetchPayload(token).map {
-                    p.clientId == (it["aud"]?.toString()
-                        ?: throw OauthParseException(oauth, "Missing 'aud' in response"))
-                }
+                fetchGoogle(token)
+                    .map {
+                        p.clientId == (it["aud"]?.toString()
+                            ?: throw OauthParseException(oauth, "Missing 'aud' in response"))
+                    }
             }
             ?: Mono.error(
                 OauthConfigException(
                     oauth,
-                    "Missing 'provider.oauth.google.client-id'"
+                    "Missing " +
+                        "'provider.oauth.google.client-id'"
                 )
             )
 
     override fun getInfo(token: String): Mono<Map<String, Any>> =
-        fetchPayload(token)
+        fetchGoogle(token)
 
-    private fun fetchPayload(token: String): Mono<Map<String, Any>> =
-        webClient.get()
-            .uri("${url}?id_token=$token")
-            .retrieve()
-            .onStatus({ it.isError }) { resp ->
-                resp.bodyToMono(String::class.java)
-                    .flatMap { Mono.error(OauthHttpException(oauth, resp.statusCode().value(), it)) }
-            }
-            .bodyToMono(object : ParameterizedTypeReference<Map<String, Any>>() {})
-            .onErrorMap {
-                when (it) {
-                    is OauthException -> it
-                    is java.net.ConnectException,
-                    is java.net.SocketTimeoutException,
-                    is org.springframework.web.reactive.function.client.WebClientRequestException ->
-                        OauthNetworkException(oauth, it)
-
-                    is com.fasterxml.jackson.core.JsonProcessingException ->
-                        OauthParseException(oauth, "Invalid JSON", it)
-
-                    is org.springframework.core.codec.DecodingException -> {
-                        val cause = it.cause
-                        if (cause is com.fasterxml.jackson.core.JsonProcessingException)
-                            OauthParseException(oauth, "Invalid JSON", cause)
-                        else OauthParseException(oauth, "Invalid JSON", it)
-                    }
-
-                    else -> OauthUnexpectedException(oauth, it)
-                }
-            }
+    private fun fetchGoogle(token: String) =
+        webClient.fetchPayload(
+            HttpMethod.GET,
+            "${props.baseUrl}${props.uri}?id_token=$token",
+            oauth
+        )
 }

--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IGoogle.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IGoogle.kt
@@ -5,7 +5,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
 internal class IGoogle internal constructor(
-    private val props: Properties.GoogleProps,
+    private val props: OauthProps.GoogleProps,
     private val webClient: WebClient
 ) : IOauth {
     private val oauth = Oauth.GOOGLE

--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IZalo.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IZalo.kt
@@ -5,7 +5,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
 internal class IZalo internal constructor(
-    private val props: Properties.ZaloProps,
+    private val props: OauthProps.ZaloProps,
     private val webClient: WebClient
 ) : IOauth {
     private val oauth = Oauth.ZALO

--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IZalo.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/IZalo.kt
@@ -1,6 +1,6 @@
 package io.github.wliamp.pro.vrf
 
-import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpMethod
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
@@ -13,7 +13,7 @@ internal class IZalo internal constructor(
     private val url = "${props.baseUrl}${props.version}${props.uri}"
 
     override fun verify(token: String): Mono<Boolean> =
-        fetchPayload("${url}?access_token=$token")
+        fetchZalo("${url}?access_token=$token")
             .map {
                 it["id"]?.toString()
                     ?: throw OauthParseException(oauth, "Missing 'id' in response")
@@ -21,42 +21,12 @@ internal class IZalo internal constructor(
             }
 
     override fun getInfo(token: String): Mono<Map<String, Any>> =
-        fetchPayload(
+        fetchZalo(
             props.fields.takeIf { it.isNotBlank() }
                 ?.let { "${url}?access_token=$token&fields=$it" }
                 ?: "${url}?access_token=$token"
         )
 
-    private fun fetchPayload(uri: String): Mono<Map<String, Any>> =
-        webClient.get()
-            .uri(uri)
-            .retrieve()
-            .onStatus({ it.isError }) { resp ->
-                resp.bodyToMono(String::class.java)
-                    .flatMap {
-                        Mono.error(OauthHttpException(oauth, resp.statusCode().value(), it))
-                    }
-            }
-            .bodyToMono(object : ParameterizedTypeReference<Map<String, Any>>() {})
-            .onErrorMap {
-                when (it) {
-                    is OauthException -> it
-                    is java.net.ConnectException,
-                    is java.net.SocketTimeoutException,
-                    is org.springframework.web.reactive.function.client.WebClientRequestException ->
-                        OauthNetworkException(oauth, it)
-
-                    is com.fasterxml.jackson.core.JsonProcessingException ->
-                        OauthParseException(oauth, "Invalid JSON", it)
-
-                    is org.springframework.core.codec.DecodingException -> {
-                        val cause = it.cause
-                        if (cause is com.fasterxml.jackson.core.JsonProcessingException)
-                            OauthParseException(oauth, "Invalid JSON", cause)
-                        else OauthParseException(oauth, "Invalid JSON", it)
-                    }
-
-                    else -> OauthUnexpectedException(oauth, it)
-                }
-            }
+    private fun fetchZalo(uri: String) =
+        webClient.fetchPayload(HttpMethod.GET, uri, oauth)
 }

--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/OauthAutoConfig.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/OauthAutoConfig.kt
@@ -9,9 +9,9 @@ import org.springframework.context.annotation.Bean
 import org.springframework.web.reactive.function.client.WebClient
 
 @AutoConfiguration
-@EnableConfigurationProperties(Properties::class)
-internal class AutoConfig private constructor(
-    private val props: Properties
+@EnableConfigurationProperties(OauthProps::class)
+internal class OauthAutoConfig private constructor(
+    private val props: OauthProps
 ) {
     @Bean
     @ConditionalOnProperty(

--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/OauthProps.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/OauthProps.kt
@@ -3,7 +3,7 @@ package io.github.wliamp.pro.vrf
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "provider.oauth")
-internal data class Properties(
+internal data class OauthProps(
     var facebook: FacebookProps = FacebookProps(),
     var google: GoogleProps = GoogleProps(),
     var zalo: ZaloProps = ZaloProps()

--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/OauthProvider.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/OauthProvider.kt
@@ -4,4 +4,11 @@ class OauthProvider(
     val facebook: IOauth?,
     val google: IOauth?,
     val zalo: IOauth?
-)
+) {
+    fun of(oauth: Oauth): IOauth? =
+        when (oauth) {
+            Oauth.FACEBOOK -> facebook
+            Oauth.GOOGLE -> google
+            Oauth.ZALO -> zalo
+        }
+}

--- a/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/Utilities.kt
+++ b/provider-verify/src/main/kotlin/io/github/wliamp/pro/vrf/Utilities.kt
@@ -1,0 +1,43 @@
+package io.github.wliamp.pro.vrf
+
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpMethod
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+internal fun WebClient.fetchPayload(
+    method: HttpMethod,
+    uri: String,
+    oauth: Oauth
+): Mono<Map<String, Any>> =
+    this.method(method)
+        .uri(uri)
+        .retrieve()
+        .onStatus({ it.isError }) { resp ->
+            resp.bodyToMono(String::class.java)
+                .flatMap {
+                    Mono.error(OauthHttpException(oauth, resp.statusCode().value(), it))
+                }
+        }
+        .bodyToMono(object : ParameterizedTypeReference<Map<String, Any>>() {})
+        .onErrorMap {
+            when (it) {
+                is OauthException -> it
+                is java.net.ConnectException,
+                is java.net.SocketTimeoutException,
+                is org.springframework.web.reactive.function.client.WebClientRequestException ->
+                    OauthNetworkException(oauth, it)
+
+                is com.fasterxml.jackson.core.JsonProcessingException ->
+                    OauthParseException(oauth, "Invalid JSON", it)
+
+                is org.springframework.core.codec.DecodingException -> {
+                    val cause = it.cause
+                    if (cause is com.fasterxml.jackson.core.JsonProcessingException)
+                        OauthParseException(oauth, "Invalid JSON", cause)
+                    else OauthParseException(oauth, "Invalid JSON", it)
+                }
+
+                else -> OauthUnexpectedException(oauth, it)
+            }
+        }

--- a/provider-verify/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.autoconfiguration.imports
+++ b/provider-verify/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.autoconfiguration.imports
@@ -1,1 +1,1 @@
-io.github.wliamp.pro.vrf.AutoConfig
+io.github.wliamp.pro.vrf.OauthAutoConfig

--- a/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/AutoConfigTest.kt
+++ b/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/AutoConfigTest.kt
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner
 class AutoConfigTest {
 
     private val baseRunner = ApplicationContextRunner()
-        .withConfiguration(AutoConfigurations.of(AutoConfig::class.java))
+        .withConfiguration(AutoConfigurations.of(OauthAutoConfig::class.java))
 
     @Test
     fun `when all enabled then all beans created`() {

--- a/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/FacebookTest.kt
+++ b/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/FacebookTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.test.StepVerifier
 
-private class FacebookTest : OauthTest<Properties.FacebookProps>({ _ ->
-    Properties.FacebookProps().apply {
+private class FacebookTest : OauthTest<OauthProps.FacebookProps>({ _ ->
+    OauthProps.FacebookProps().apply {
         appId = "test-app"
         accessToken = "test-access-token"
         baseUrl = ""
@@ -15,7 +15,7 @@ private class FacebookTest : OauthTest<Properties.FacebookProps>({ _ ->
         infoUri = "/me"
     }
 }) {
-    override fun buildProvider(props: Properties.FacebookProps, client: WebClient): IOauth =
+    override fun buildProvider(props: OauthProps.FacebookProps, client: WebClient): IOauth =
         IFacebook(props, client)
 
     @Test
@@ -56,7 +56,7 @@ private class FacebookTest : OauthTest<Properties.FacebookProps>({ _ ->
 
     @Test
     fun `verify errors when config missing appId`() {
-        val bad = Properties.FacebookProps().apply {
+        val bad = OauthProps.FacebookProps().apply {
             appId = ""
             accessToken = "test-access-token"
             baseUrl = ""
@@ -70,7 +70,7 @@ private class FacebookTest : OauthTest<Properties.FacebookProps>({ _ ->
 
     @Test
     fun `verify errors when config missing accessToken`() {
-        val bad = Properties.FacebookProps().apply {
+        val bad = OauthProps.FacebookProps().apply {
             appId = "test-app"
             accessToken = ""
             baseUrl = ""
@@ -84,7 +84,7 @@ private class FacebookTest : OauthTest<Properties.FacebookProps>({ _ ->
 
     @Test
     fun `getInfo works when fields config empty`() {
-        val bad = Properties.FacebookProps().apply {
+        val bad = OauthProps.FacebookProps().apply {
             appId = "test-app"
             accessToken = "test-access-token"
             baseUrl = ""
@@ -131,7 +131,7 @@ private class FacebookTest : OauthTest<Properties.FacebookProps>({ _ ->
 
     @Test
     fun `getInfo builds correct uri with fields`() {
-        val customProps = Properties.FacebookProps().apply {
+        val customProps = OauthProps.FacebookProps().apply {
             appId = "test-app"
             accessToken = "test-access-token"
             baseUrl = props.baseUrl

--- a/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/GoogleTest.kt
+++ b/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/GoogleTest.kt
@@ -5,13 +5,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.test.StepVerifier
 
-private class GoogleTest : OauthTest<Properties.GoogleProps>({ _ ->
-    Properties.GoogleProps().apply {
+private class GoogleTest : OauthTest<OauthProps.GoogleProps>({ _ ->
+    OauthProps.GoogleProps().apply {
         clientId = "test-client"
         baseUrl = ""
     }
 }) {
-    override fun buildProvider(props: Properties.GoogleProps, client: WebClient): IOauth =
+    override fun buildProvider(props: OauthProps.GoogleProps, client: WebClient): IOauth =
         IGoogle(props, client)
 
     @Test
@@ -43,7 +43,7 @@ private class GoogleTest : OauthTest<Properties.GoogleProps>({ _ ->
 
     @Test
     fun `verify errors when config missing clientId`() {
-        val bad = Properties.GoogleProps().apply {
+        val bad = OauthProps.GoogleProps().apply {
             clientId = ""
             baseUrl = ""
         }

--- a/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/PropsBindingTest.kt
+++ b/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/PropsBindingTest.kt
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner
 class PropsBindingTest {
 
     private val baseRunner = ApplicationContextRunner()
-        .withConfiguration(AutoConfigurations.of(AutoConfig::class.java))
+        .withConfiguration(AutoConfigurations.of(OauthAutoConfig::class.java))
 
     @Test
     fun `properties should bind correctly`() {
@@ -24,7 +24,7 @@ class PropsBindingTest {
                 "provider.oauth.zalo.fields=id,picture"
             )
             .run {
-                val props = it.getBean(Properties::class.java)
+                val props = it.getBean(OauthProps::class.java)
 
                 assertThat(props.facebook.baseUrl).isEqualTo("https://custom.fb")
                 assertThat(props.facebook.appId).isEqualTo("fb-app")
@@ -42,7 +42,7 @@ class PropsBindingTest {
     @Test
     fun `defaults should apply when no config provided`() {
         baseRunner.run {
-            val props = it.getBean(Properties::class.java)
+            val props = it.getBean(OauthProps::class.java)
 
             assertThat(props.facebook.baseUrl).isEqualTo("https://graph.facebook.com")
             assertThat(props.google.baseUrl).isEqualTo("https://oauth2.googleapis.com")

--- a/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/ZaloTest.kt
+++ b/provider-verify/src/test/kotlin/io/github/wliamp/pro/vrf/ZaloTest.kt
@@ -5,15 +5,15 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.test.StepVerifier
 
-private class ZaloTest : OauthTest<Properties.ZaloProps>({ _ ->
-    Properties.ZaloProps().apply {
+private class ZaloTest : OauthTest<OauthProps.ZaloProps>({ _ ->
+    OauthProps.ZaloProps().apply {
         baseUrl = ""
         version = "/v2.0"
         uri = "/me"
         fields = ""
     }
 }) {
-    override fun buildProvider(props: Properties.ZaloProps, client: WebClient): IOauth =
+    override fun buildProvider(props: OauthProps.ZaloProps, client: WebClient): IOauth =
         IZalo(props, client)
 
     @Test
@@ -66,7 +66,7 @@ private class ZaloTest : OauthTest<Properties.ZaloProps>({ _ ->
 
     @Test
     fun `getInfo builds correct uri with fields`() {
-        val customProps = Properties.ZaloProps().apply {
+        val customProps = OauthProps.ZaloProps().apply {
             baseUrl = props.baseUrl
             version = props.version
             uri = props.uri


### PR DESCRIPTION
#### Summary
This PR updates the `pro-vrf` module to support provider lookup by enum in OauthProvider
and refactors related code for clarity, maintainability, and test coverage.

#### Changes
- Feature: Add support for looking up providers by enum in `OauthProvider`.
- Refactor: Optimize OauthProvider-related code for better readability and structure.
- Refactor: Rename Oauth classes, variables, and corresponding tests for consistency.
